### PR TITLE
chore: Update `actions/cache`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@actions/github": "^5.1.1",
     "@actions/tool-cache": "^2.0.1",
     "@octokit/plugin-throttling": "^5.0.1",
-    "@actions/cache": "^3.2.4",
+    "@actions/cache": "^4.0.3",
     "ajv": "^8.17.1",
     "js-yaml": "^4.1.0",
     "eslint": "^9.2.0",


### PR DESCRIPTION
## what
- Bump `actions/cache` to > `v4`

## why

> All previous versions of this package will be deprecated. We recommend upgrading to version 4.0.0 as soon as possible before February 1st, 2025.
> 
> If you do not upgrade, all workflow runs using any of the deprecated [@actions/cache](https://github.com/actions/toolkit/tree/main/packages/cache) packages will fail.
> 
> Upgrading to the recommended version should not break or require any changes to your workflows beyond updating your package.json to version

 4.0.0.

## references
- https://www.npmjs.com/package/@actions/cache