### PR TITLE
Fix CI typescript workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-dist:
     name: "check-dist matches source"
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-typescript-app-check-dist.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-ci-typescript-app-check-dist.yml@main
     with:
       node-version: 20.x
 


### PR DESCRIPTION
## what
* Fix CI typescript workflow

## why
* The workflow `cloudposse/github-actions-workflows/blob/main/.github/workflows/ci-typescript-app-check-dist.yml` is archived

## references
* https://github.com/cloudposse-github-actions/install-gh-releases/actions/runs/16988911964