### PR TITLE
Replace Makefile with atmos.yaml

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -22,5 +22,5 @@ permissions:
 
 jobs:
   github-action:
-    uses: cloudposse-github-actions/.github/.github/workflows/ci.yml@main
+    uses: cloudposse-github-actions/.github/.github/workflows/shared-github-action.yml@main
     secrets: inherit


### PR DESCRIPTION
## what
- Remove `Makefile`
- Add `atmos.yaml`

## why
- Replace `build-harness` with `atmos` for readme genration

## References
* DEV-3229 Migrate from build-harness to atmos
